### PR TITLE
Uplifting state from individual tabs to main chat

### DIFF
--- a/app/reactjs/oa/src/chat.js
+++ b/app/reactjs/oa/src/chat.js
@@ -60,15 +60,24 @@ class ChatLayout extends React.Component {
                         inputPlaceholder: 'Create or join room...',
                     },
                 }, {
+                    title: 'ReactJS',
+                    type: 'react-component',
+                    component: 'chat-window',
+                    props: {
+                        items: ['sample message'],
+                        title: 'reactjs',
+                        inputPlaceholder: 'Send a message...',
+                    },
+                }, {
                     title: 'Lobby',
                     type: 'react-component',
                     component: 'chat-window',
                     props: {
                         items: ['sample message'],
-                        title: 'Lobby',
+                        title: 'lobby',
                         inputPlaceholder: 'Send a message...',
                     },
-                }]
+                }, ]
             }]
         };
         return config;

--- a/app/reactjs/oa/src/core_elems.js
+++ b/app/reactjs/oa/src/core_elems.js
@@ -1,50 +1,7 @@
-import React from "react";
-
-
-class InputField extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            value: props.value,
-            name: props.name,
-            placeholder: props.placeholder,
-            onSubmit: props.onSubmit,
-        };
-
-        this.handleChange = this.handleChange.bind(this);
-        this.keyPress = this.keyPress.bind(this);
-    }
-
-    handleChange(e) {
-        const new_value = e.target.value;
-        this.setState({value: new_value})
-    }
-
-    keyPress(e) {
-        if(enterKeyPressed(e)) {
-            return this.state.onSubmit(this.state.value);
-        }
-    }
-
-    render() {
-        return (
-            <input
-                className=".inputBox"
-                key={"inputBox_" + this.state.name}
-                id={this.state.name}
-                type="text" value={this.state.value}
-                placeholder={this.state.placeholder}
-                onKeyPress={this.keyPress}
-                onChange={this.handleChange}
-            />
-        )
-    }
-}
-
 function enterKeyPressed(e) {
     let code = e.keyCode || e.which;
     return code === 13
 }
 
 
-export {InputField}
+export {enterKeyPressed}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 # OpenAnswer
 
 Chat with us on [gitter](https://gitter.im/openanswer-io/Lobby#).
+Contributions are welcome. Things may change and break without notice (this project is still in its infancy).
+For questions/comments/feedback/support please open an issue [here]('https://github.com/openanswer/OpenAnswer/issues).


### PR DESCRIPTION
Initial steps to move socket connection out of each tab to the overall chat.  This way we don't keep opening socket connections per room, replicating the existing behavior. Chat tabs will emit events to global event hub. Global event hub will then emit events to socketio.

```
Chat -- EventHub -- SocketIO
   |           \        /
   Room List -- EventHub
   |             |    |
   Lobby ------ EventHub
```